### PR TITLE
releasetools: Add support for LZMA in blockimgdiff

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1690,6 +1690,7 @@ $(INTERNAL_OTA_PACKAGE_TARGET): $(BUILT_TARGET_FILES_PACKAGE) $(DISTTOOLS)
 	$(hide) MKBOOTIMG=$(MKBOOTIMG) \
 	   $(OTA_FROM_TARGET_SCRIPT) -v \
 	   --block \
+	   $(if $(WITH_LZMA_OTA), -z) \
 	   -p $(HOST_OUT) \
 	   -k $(KEY_CERT_PAIR) \
 	   --backup=$(backuptool) \

--- a/tools/releasetools/ota_from_target_files
+++ b/tools/releasetools/ota_from_target_files
@@ -70,6 +70,10 @@ Usage:  ota_from_target_files [flags] input_target_files output_ota_package
       file-based OTA if the target_files is older and doesn't support
       block-based OTAs.
 
+  -z  Compress the block-based image using LZMA. Results in substantial
+      space reduction at the cost of longer compress/decompress time.
+      Requires the "backports.lzma" module to be installed.
+
   -b  (--binary)  <file>
       Use the given binary as the update-binary in the output package,
       instead of the binary in the build's target_files.  Use for
@@ -139,6 +143,7 @@ OPTIONS.fallback_to_full = True
 OPTIONS.backuptool = False
 OPTIONS.override_device = 'auto'
 OPTIONS.override_prop = False
+OPTIONS.use_lzma = False
 
 def MostPopularKey(d, default):
   """Given a dict, return the key corresponding to the largest
@@ -616,7 +621,7 @@ else if get_stage("%(bcb_dev)s") == "3/3" then
     # writes incrementals to do it.
     system_tgt = GetImage("system", OPTIONS.input_tmp, OPTIONS.info_dict)
     system_tgt.ResetFileMap()
-    system_diff = common.BlockDifference("system", system_tgt, src=None)
+    system_diff = common.BlockDifference("system", system_tgt, src=None, use_lzma=OPTIONS.use_lzma)
     system_diff.WriteScript(script, output_zip)
   else:
     script.FormatPartition("/system")
@@ -648,7 +653,7 @@ else if get_stage("%(bcb_dev)s") == "3/3" then
     if block_based:
       vendor_tgt = GetImage("vendor", OPTIONS.input_tmp, OPTIONS.info_dict)
       vendor_tgt.ResetFileMap()
-      vendor_diff = common.BlockDifference("vendor", vendor_tgt)
+      vendor_diff = common.BlockDifference("vendor", vendor_tgt, use_lzma=OPTIONS.use_lzma)
       vendor_diff.WriteScript(script, output_zip)
     else:
       script.FormatPartition("/vendor")
@@ -812,7 +817,7 @@ def WriteBlockIncrementalOTAPackage(target_zip, source_zip, output_zip):
   system_src = GetImage("system", OPTIONS.source_tmp, OPTIONS.source_info_dict)
   system_tgt = GetImage("system", OPTIONS.target_tmp, OPTIONS.target_info_dict)
   system_diff = common.BlockDifference("system", system_tgt, system_src,
-                                       check_first_block=True)
+                                       check_first_block=True, use_lzma=OPTIONS.use_lzma)
 
   if HasVendorPartition(target_zip):
     if not HasVendorPartition(source_zip):
@@ -820,7 +825,7 @@ def WriteBlockIncrementalOTAPackage(target_zip, source_zip, output_zip):
     vendor_src = GetImage("vendor", OPTIONS.source_tmp, OPTIONS.source_info_dict)
     vendor_tgt = GetImage("vendor", OPTIONS.target_tmp, OPTIONS.target_info_dict)
     vendor_diff = common.BlockDifference("vendor", vendor_tgt, vendor_src,
-                                         check_first_block=True)
+                                         check_first_block=True, use_lzma=OPTIONS.use_lzma)
   else:
     vendor_diff = None
 
@@ -1517,12 +1522,16 @@ def main(argv):
       OPTIONS.override_device = a
     elif o in ("--override_prop"):
       OPTIONS.override_prop = bool(a.lower() == 'true')
+    elif o in ("-z", "--use_lzma"):
+      OPTIONS.use_lzma = True
+      # Import now, and bomb out if backports.lzma isn't installed
+      from backports import lzma
     else:
       return False
     return True
 
   args = common.ParseOptions(argv, __doc__,
-                             extra_opts="b:k:i:d:wne:t:a:2o:",
+                             extra_opts="b:k:i:d:wne:t:a:2o:z",
                              extra_long_opts=["board_config=",
                                               "package_key=",
                                               "incremental_from=",
@@ -1540,7 +1549,8 @@ def main(argv):
                                               "no_fallback_to_full",
                                               "backup=",
                                               "override_device=",
-                                              "override_prop="],
+                                              "override_prop=",
+                                              "use_lzma"],
                              extra_option_handler=option_handler)
 
   if len(args) != 2:


### PR DESCRIPTION
 * Requires backports.lzma to be installed for Python2.
 * To enable, set WITH_LZMA_OTA to true in the build environment.
 * This results in significantly smaller OTA packages, which results
   in less $$$ being paid to deliver said OTAs. Unfortunately it is
   also significantly slower to decompress (parallelization may help).

Change-Id: If4b8092718aa6623cfff101030eabd24cde8763c