### PR TITLE
Change the cache partition size check into warnings.

### DIFF
--- a/tools/releasetools/blockimgdiff.py
+++ b/tools/releasetools/blockimgdiff.py
@@ -455,7 +455,7 @@ class BlockImageDiff(object):
       if free_string:
         out.append("".join(free_string))
 
-      if self.version >= 2:
+      if self.version >= 2 and common.OPTIONS.cache_size is not None:
         # Sanity check: abort if we're going to need more stash space than
         # the allowed size (cache_size * threshold). There are two purposes
         # of having a threshold here. a) Part of the cache may have been
@@ -497,10 +497,16 @@ class BlockImageDiff(object):
 
     if self.version >= 2:
       max_stashed_size = max_stashed_blocks * self.tgt.blocksize
-      max_allowed = common.OPTIONS.cache_size * common.OPTIONS.stash_threshold
-      print("max stashed blocks: %d  (%d bytes), limit: %d bytes (%.2f%%)\n" % (
-          max_stashed_blocks, max_stashed_size, max_allowed,
-          max_stashed_size * 100.0 / max_allowed))
+      OPTIONS = common.OPTIONS
+      if OPTIONS.cache_size is not None:
+        max_allowed = OPTIONS.cache_size * OPTIONS.stash_threshold
+        print("max stashed blocks: %d  (%d bytes), "
+              "limit: %d bytes (%.2f%%)\n" % (
+              max_stashed_blocks, max_stashed_size, max_allowed,
+              max_stashed_size * 100.0 / max_allowed))
+      else:
+        print("max stashed blocks: %d  (%d bytes), limit: <unknown>\n" % (
+              max_stashed_blocks, max_stashed_size))
 
   def ReviseStashSize(self):
     print("Revising stash size...")

--- a/tools/releasetools/common.py
+++ b/tools/releasetools/common.py
@@ -67,6 +67,10 @@ OPTIONS.device_specific = None
 OPTIONS.extras = {}
 OPTIONS.info_dict = None
 
+# Stash size cannot exceed cache_size * threshold.
+OPTIONS.cache_size = None
+OPTIONS.stash_threshold = 0.8
+
 
 # Values for "certificate" in apkcerts that mean special things.
 SPECIAL_CERT_STRINGS = ("PRESIGNED", "EXTERNAL")

--- a/tools/releasetools/ota_from_target_files
+++ b/tools/releasetools/ota_from_target_files
@@ -144,9 +144,6 @@ OPTIONS.block_based = False
 OPTIONS.updater_binary = None
 OPTIONS.oem_source = None
 OPTIONS.fallback_to_full = True
-# Stash size cannot exceed cache_size * threshold.
-OPTIONS.cache_size = None
-OPTIONS.stash_threshold = 0.8
 OPTIONS.backuptool = False
 OPTIONS.override_device = 'auto'
 OPTIONS.override_prop = False
@@ -1644,7 +1641,7 @@ def main(argv):
 
     cache_size = OPTIONS.info_dict.get("cache_size", None)
     if cache_size is None:
-      raise RuntimeError("can't determine the cache partition size")
+      print "--- can't determine the cache partition size ---"
     OPTIONS.cache_size = cache_size
 
     if OPTIONS.incremental_source is None:


### PR DESCRIPTION
For some old builds, we may not define cache partition size. Change the
exception into a warning to make the script backward compatible.

Change-Id: Ie94c7fbb1a9f3a7db3f16e8d845e493a534aac5b